### PR TITLE
Escape backslashes

### DIFF
--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -27,7 +27,7 @@ function load_blocks() {
 		}
 	}
 }
-add_action( 'init', __NAMESPACE__ . '\load_blocks', 5 );
+add_action( 'init', __NAMESPACE__ . '\\load_blocks', 5 );
 
 /**
  * Load ACF field groups for blocks
@@ -39,7 +39,7 @@ function load_acf_field_group( $paths ) {
 	}
 	return $paths;
 }
-add_filter( 'acf/settings/load_json', __NAMESPACE__ . '\load_acf_field_group' );
+add_filter( 'acf/settings/load_json', __NAMESPACE__ . '\\load_acf_field_group' );
 
 /**
  * Get Blocks


### PR DESCRIPTION
Although `\l` in single quotes does not mean an escape sequence, the safe way is to always use two backslashes.
https://www.php.net/manual/en/regexp.reference.escape.php

This PR touches only 1 file.